### PR TITLE
refactor(core): avoid relying on `use` outside

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -189,6 +189,6 @@ impl AsyncServices for ServiceContainer {
 #[macro_export]
 macro_rules! alias {
     ($int: ty, $act: ty $(,)?) => {
-        |c| c.get::<$act>().map(|s| s as Arc<$int>)
+        |c| c.get::<$act>().map(|s| s as ::std::sync::Arc<$int>)
     };
 }


### PR DESCRIPTION
`alias` マクロ内で外部のインポートに頼っている問題を修正します